### PR TITLE
Don't use -lcrypt on OS X

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -23,17 +23,18 @@ ifeq ($(UNAME_SYS), Darwin)
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	LDFLAGS ?= -lcrypt
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= cc
 	CFLAGS ?= -DHAVE_CRYPT_R -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	LDFLAGS ?= -lpthread
+	LDFLAGS ?= -lpthread -lcrypt
 endif
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
 LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
-LDFLAGS += -lcrypt -shared
+LDFLAGS += -shared
 
 # Verbosity.
 


### PR DESCRIPTION
OS X doesn't require `-lcrypt`, and building fails with it. According to http://lists.apple.com/archives/unix-porting/2005/Dec/msg00018.html, the crypt function is in the system C library.