### PR TITLE
crypt.c: remove pragmas

### DIFF
--- a/c_src/crypt.c
+++ b/c_src/crypt.c
@@ -51,10 +51,7 @@
 
 #include "explicit_bzero.h"
 
-#ifdef HAVE_CRYPT_R
-#pragma message "using crypt_r"
-#else
-#pragma message "using crypt"
+#ifndef HAVE_CRYPT_R
 struct PrivData {
   ErlNifMutex *mutex;
 };


### PR DESCRIPTION
On some compilers, pragma messages are treated as a warning.
If -Werror is set, as appears to be done by mix or rebar,
this would mean the compilation would erroneously fail.