### PR TITLE
explicit_bzero.c: Define _POSIX_C_SOURCE for bzero

### DIFF
--- a/c_src/explicit_bzero.c
+++ b/c_src/explicit_bzero.c
@@ -5,6 +5,9 @@
  * Written by Ted Unangst
  */
 
+// bzero() got removed in POSIX.1-2008, got deprecated in POSIX.1-2001
+#define _POSIX_C_SOURCE 200112L
+
 #include <string.h>
 #include <strings.h>
 


### PR DESCRIPTION
This fixes building on musl libc, which hides bzero behind
_POSIX_C_SOURCE+0 < 200809L among other similar conditions which are more
prone to change.

A more future-proof solution should probably be tried as bzero has been
legacy for a long time.