### PR TITLE
makefile: Obey generic CPPFLAGS/CFLAGS/LDFLAGS from the env.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -15,30 +15,28 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 CC ?= cc
 
 UNAME_SYS := $(shell uname -s)
+CFLAGS_CRYPT = -finline-functions -std=c99 -fPIC -I $(ERTS_INCLUDE_DIR)
 ifeq ($(UNAME_SYS), Darwin)
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	LDFLAGS ?= -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -Wall -Wmissing-prototypes
+	LIBS = -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), Linux)
 	UNAME_OP := $(shell uname -o)
   ifeq ($(UNAME_OP), Android)
-		CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-		LDFLAGS ?= -lcrypt
+		CFLAGS ?= -O3 -Wall -Wmissing-prototypes
+		LIBS = -lcrypt
   else
-		CFLAGS ?= -DHAVE_CRYPT_R -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes \
-			-pedantic -fwrapv -D_FORTIFY_SOURCE=2 \
+		CFLAGS_CRYPT += -DHAVE_CRYPT_R -fwrapv -fno-strict-aliasing
+		CFLAGS ?= -O3 -Wall -Wmissing-prototypes \
+			-pedantic -D_FORTIFY_SOURCE=2 \
 			-fstack-protector-strong -Wformat -Werror=format-security \
-			-fno-strict-aliasing -Wconversion -Wshadow -Wpointer-arith \
-			-Wcast-qual
-		LDFLAGS ?= -lpthread -lcrypt -Wl,-z,relro,-z,now -Wl,-z,noexecstack
+			-Wconversion -Wshadow -Wpointer-arith -Wcast-qual
+		LIBS = -lpthread -lcrypt
+		LDFLAGS ?= -Wl,-z,relro,-z,now -Wl,-z,noexecstack
   endif
 else ifneq (,$(wildcard /usr/lib/libcrypt.*))
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	LDFLAGS ?= -lcrypt
+	CFLAGS ?= -O3 -Wall -Wmissing-prototypes
+	LIBS = -lcrypt
 endif
-
-CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR)
-
-LDFLAGS += -shared
 
 # Verbosity.
 
@@ -51,11 +49,12 @@ link_verbose = $(link_verbose_$(V))
 SOURCES := $(shell find $(C_SRC_DIR) -type f \( -name "*.c" -o -name "*.C" -o -name "*.cc" -o -name "*.cpp" \))
 OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
 
-COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) -c
+COMPILE_C = $(c_verbose) $(CC) $(CPPFLAGS) $(CFLAGS_CRYPT) $(CFLAGS) -c
+LINK_C = $(link_verbose) $(CC) $(CFLAGS) $(LDFLAGS) -shared
 
 $(C_SRC_OUTPUT): $(OBJECTS)
 	@mkdir -p $(BASEDIR)/priv/
-	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) -o $(C_SRC_OUTPUT)
+	$(LINK_C) $(OBJECTS) $(LIBS) -o $(C_SRC_OUTPUT)
 
 %.o: %.c
 	$(COMPILE_C) $(OUTPUT_OPTION) $<


### PR DESCRIPTION
Most Linux packaging systems provide generic CPPFLAGS/CFLAGS/LDFLAGS environement variables that should be used by every package.  These flags are generic and mostly contain CPU architecture, build reproducibility and security options.  Not obeying them generally leads to problems with the package.

crypt/Makefile does not expect this, it ignores CPPFLAGS, does not set HAVE_CRYPT_R correctly if CFLAGS are given and does not link to any library when LDFLAGS are given.

This is even more a problem when this library is part of a larger project since rebar3/mix do not provide ways to customize CFLAGS for every dependency.

This patches separate essential project-specific flags (C standard & libraries) from generic options and make *FLAGS only replace generic options.  It also uses CFLAGS when linking.