### PR TITLE
Fix memory leak

### DIFF
--- a/c_src/crypt.c
+++ b/c_src/crypt.c
@@ -108,8 +108,10 @@ static ERL_NIF_TERM nif_crypt(ErlNifEnv *env, int argc,
 
   key_bin.data[key_bin.size - 1] = '\0';
 
-  if (!enif_realloc_binary(&salt_bin, salt_bin.size + 1))
+  if (!enif_realloc_binary(&salt_bin, salt_bin.size + 1)) {
+    enif_release_binary(&key_bin);
     return enif_make_badarg(env);
+  }
 
   salt_bin.data[salt_bin.size - 1] = '\0';
 
@@ -124,6 +126,10 @@ static ERL_NIF_TERM nif_crypt(ErlNifEnv *env, int argc,
 #endif
   /* Clean up the copy of the key */
   explicit_bzero(key_bin.data, key_bin.size);
+  /* these realloc:ed binaries need to be released */
+  enif_release_binary(&key_bin);
+  enif_release_binary(&salt_bin);
+
   if (result == NULL)
     return enif_make_badarg(env);
 


### PR DESCRIPTION
Binaries created by  `enif_realloc_binary` have to be explicitly released with  `enif_release_binary`

This is true even for binaries created by `enif_inspect_iolist_as_binary`. The original
bin data is transient and cleaned up at the end of the call, but the realloc:ed data isn't

Example: without this patch two binaries are leaked for each call
```erlang
Eshell V13.2.2.7  (abort with ^G)
1> crypt:crypt(<<"12345678">>, <<"$6$">>).
<<"$6K56VBkj3bXw">>
2> instrument:allocations().
{ok,{128,0,
     #{crypt =>
           #{drv_binary => {2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},
...
```
